### PR TITLE
Fix crash: Permission denial ... revoked permission android.permissio…

### DIFF
--- a/app/src/main/java/org/macho/beforeandafter/record/editaddrecord/EditAddRecordFragment.kt
+++ b/app/src/main/java/org/macho/beforeandafter/record/editaddrecord/EditAddRecordFragment.kt
@@ -48,6 +48,7 @@ class EditAddRecordFragment @Inject constructor() : DaggerFragment(), EditAddRec
     companion object {
         const val GALLERY_PERMISSION_RC = 1
         const val CAMERA_PERMISSION_RC = 2
+        const val OTHER_CAMERA_PERMISSION_RC = 6
         const val CUSTOM_CAMERA_RC = 3
         const val OS_CAMERA_RC = 4
         const val GALLERY_RC = 5
@@ -152,6 +153,11 @@ class EditAddRecordFragment @Inject constructor() : DaggerFragment(), EditAddRec
             CAMERA_PERMISSION_RC -> {
                 if (PermissionUtils.permissionGranted(requestCode, CAMERA_PERMISSION_RC, grantResults)) {
                     presenter.onCameraButtonClicked(currentImageIndex ?: throw RuntimeException("currentImageIndex must not be null."))
+                }
+            }
+            OTHER_CAMERA_PERMISSION_RC -> {
+                if (PermissionUtils.permissionGranted(requestCode, OTHER_CAMERA_PERMISSION_RC, grantResults)) {
+                    startOtherCameraApp()
                 }
             }
             GALLERY_PERMISSION_RC -> {
@@ -292,10 +298,15 @@ class EditAddRecordFragment @Inject constructor() : DaggerFragment(), EditAddRec
     }
 
     private fun startOtherCameraApp() {
-        val intent = Intent(MediaStore.ACTION_IMAGE_CAPTURE)
-        val uri = FileProvider.getUriForFile(context!!, "${BuildConfig.APPLICATION_ID}.fileprovider", getCameraFile())
-        intent.putExtra(MediaStore.EXTRA_OUTPUT, uri)
-        startActivityForResult(intent, OS_CAMERA_RC)
+        if (PermissionUtils.requestPermission(this, OTHER_CAMERA_PERMISSION_RC,
+                        Manifest.permission.READ_EXTERNAL_STORAGE,
+                        Manifest.permission.CAMERA)) {
+
+            val intent = Intent(MediaStore.ACTION_IMAGE_CAPTURE)
+            val uri = FileProvider.getUriForFile(context!!, "${BuildConfig.APPLICATION_ID}.fileprovider", getCameraFile())
+            intent.putExtra(MediaStore.EXTRA_OUTPUT, uri)
+            startActivityForResult(intent, OS_CAMERA_RC)
+        }
     }
 
     private fun saveUriToFile(uri: Uri, toFile: File) {


### PR DESCRIPTION
以下のクラッシュの修正。

`MediaStore.ACTION_IMAGE_CAPTURE`で他のカメラアプリを開く場合でも、以下のパーミッションが必要
- android.permission.CAMERA
- android.permission.READ_EXTERNAL_STORAGE

```
Fatal Exception: java.lang.SecurityException: Permission Denial: starting Intent { act=android.media.action.IMAGE_CAPTURE flg=0x3 cmp=com.sec.android.app.camera/.Camera clip={text/uri-list U:content://org.macho.beforeandafter.fileprovider/tempfile_path/temp.jpg} (has extras) } from ProcessRecord{f3d8c3e 30528:org.macho.beforeandafter/u0a6380} (pid=30528, uid=16380) with revoked permission android.permission.CAMERA
       at android.os.Parcel.createException(Parcel.java:2088)
       at android.os.Parcel.readException(Parcel.java:2056)
       at android.os.Parcel.readException(Parcel.java:2004)
       at android.app.IActivityTaskManager$Stub$Proxy.startActivity(IActivityTaskManager.java:4328)
       at android.app.Instrumentation.execStartActivity(Instrumentation.java:1713)
       at android.app.Activity.startActivityForResult(Activity.java:5252)
       at androidx.fragment.app.FragmentActivity.startActivityForResult(FragmentActivity.java:675)
       at androidx.core.app.ActivityCompat.startActivityForResult(ActivityCompat.java:234)
       at androidx.fragment.app.FragmentActivity.startActivityFromFragment(FragmentActivity.java:795)
       at androidx.fragment.app.FragmentActivity$HostCallbacks.onStartActivityFromFragment(FragmentActivity.java:932)
       at androidx.fragment.app.Fragment.startActivityForResult(Fragment.java:1275)
       at androidx.fragment.app.Fragment.startActivityForResult(Fragment.java:1263)
       at org.macho.beforeandafter.record.editaddrecord.EditAddRecordFragment.startOtherCameraApp(EditAddRecordFragment.java:298)
...
```