### PR TITLE
Crashlytics対応

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -15,8 +15,8 @@ android {
         applicationId "org.macho.beforeandafter"
         minSdkVersion 21
         targetSdkVersion 29
-        versionCode 85
-        versionName "2.5.5"
+        versionCode 86
+        versionName "2.5.6"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
     buildTypes {

--- a/app/src/main/java/org/macho/beforeandafter/preference/backup/BackupPresenter.kt
+++ b/app/src/main/java/org/macho/beforeandafter/preference/backup/BackupPresenter.kt
@@ -164,6 +164,9 @@ class BackupPresenter @Inject constructor(val recordRepository: RecordRepository
             BackupTask.BackupStatus.BACKUP_STATUS_CODE_ERROR_TIMEOUT -> {
                 view?.showAlert(context.getString(R.string.backup_error_title), context.getString(R.string.backup_error_files_create_failed))
             }
+            BackupTask.BackupStatus.BACKUP_STATUS_CODE_ERROR_NO_ENOUGH_SPACE -> {
+                view?.showAlert(context.getString(R.string.backup_error_title), context.getString(R.string.backup_error_no_enough_space))
+            }
             BackupTask.BackupStatus.BACKUP_STATUS_CODE_ERROR_RECOVERABLE -> {
                 val intent = backupTask?.recoverableAuthIOException?.intent ?: return
                 view?.startActivityForResult(intent, RC_RECOVERABLE)

--- a/app/src/main/java/org/macho/beforeandafter/preference/restore/RestoreTask.kt
+++ b/app/src/main/java/org/macho/beforeandafter/preference/restore/RestoreTask.kt
@@ -57,7 +57,7 @@ class RestoreTask(context: Context, val account: Account, listener: RestoreTaskL
             }
 
             backupData.records.forEach {
-                RecordDaoImpl().update(it)
+                RecordDaoImpl().createOrUpdate(it)
             }
 
             val existingRestoreImages = RestoreImageDaoImpl().findAll()

--- a/app/src/main/java/org/macho/beforeandafter/shared/data/record/RecordDao.kt
+++ b/app/src/main/java/org/macho/beforeandafter/shared/data/record/RecordDao.kt
@@ -5,9 +5,7 @@ interface RecordDao {
 
     fun find(date: Long): Record?
 
-    fun register(record: Record)
-
-    fun update(record: Record)
+    fun createOrUpdate(record: Record)
 
     fun delete(date: Long)
 

--- a/app/src/main/java/org/macho/beforeandafter/shared/data/record/RecordDaoImpl.kt
+++ b/app/src/main/java/org/macho/beforeandafter/shared/data/record/RecordDaoImpl.kt
@@ -45,23 +45,7 @@ class RecordDaoImpl: RecordDao {
         }
     }
 
-    override fun register(record: Record) {
-        Realm.getDefaultInstance().use {
-            it.executeTransaction { realm ->
-                var registered = realm.createObject(RecordDto::class.java, record.date)
-                registered.weight = record.weight
-                registered.rate = record.rate
-                registered.frontImagePath = record.frontImagePath
-                registered.sideImagePath = record.sideImagePath
-                registered.otherImagePath1 = record.otherImagePath1
-                registered.otherImagePath2 = record.otherImagePath2
-                registered.otherImagePath3 = record.otherImagePath3
-                registered.memo = record.memo
-            }
-        }
-    }
-
-    override fun update(record: Record) {
+    override fun createOrUpdate(record: Record) {
         Realm.getDefaultInstance().use {
             it.executeTransaction { realm ->
                 realm.copyToRealmOrUpdate(RecordDto(

--- a/app/src/main/java/org/macho/beforeandafter/shared/data/record/RecordRepositoryImpl.kt
+++ b/app/src/main/java/org/macho/beforeandafter/shared/data/record/RecordRepositoryImpl.kt
@@ -24,7 +24,7 @@ class RecordRepositoryImpl @Inject constructor(val recordDao: RecordDao, val app
 
     override fun register(record: Record, onComplete: (() -> Unit)?) {
         appExecutors.diskIO.execute {
-            recordDao.register(record)
+            recordDao.createOrUpdate(record)
             appExecutors.mainThread.execute {
                 if (onComplete == null) {
                     return@execute
@@ -36,7 +36,7 @@ class RecordRepositoryImpl @Inject constructor(val recordDao: RecordDao, val app
 
     override fun update(record: Record, onComplete: (() -> Unit)?) {
         appExecutors.diskIO.execute {
-            recordDao.update(record)
+            recordDao.createOrUpdate(record)
             appExecutors.mainThread.execute {
                 if (onComplete == null) {
                     return@execute

--- a/app/src/main/res/values-en/string.xml
+++ b/app/src/main/res/values-en/string.xml
@@ -170,6 +170,7 @@
     <string name="backup_error_description_no_records">There is no records to backup.</string>
     <string name="backup_error_drive_connection_error">We cannot connect to Google Drive.</string>
     <string name="backup_error_files_create_failed">Failed to upload image files.</string>
+    <string name="backup_error_no_enough_space">There is not enough free space in Google Drive of this Google account.</string>
     <string name="backup_error_network_timeout">Network timeout occurred. try again later.</string>
 
     <string name="restore_dialog_title">Restore</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -170,6 +170,7 @@
     <string name="backup_error_description_no_records">バックアップする記録データがありません。</string>
     <string name="backup_error_drive_connection_error">GoogleDriveとの接続に失敗しました。</string>
     <string name="backup_error_files_create_failed">画像ファイルのアップロードに失敗しました。</string>
+    <string name="backup_error_no_enough_space">このGoogleアカウントのGoogle Driveには十分な空き容量がありません。</string>
     <string name="backup_error_network_timeout">ネットワークが安定しないため、タイムアウトエラーが発生しました。しばらくしてからもう一度お試しください。</string>
 
     <string name="restore_dialog_title">バックアップデータの復元</string>


### PR DESCRIPTION
# RealmPrimaryKeyConstraintException: Primary key value already exists

```
Fatal Exception: io.realm.exceptions.RealmPrimaryKeyConstraintException: Primary key value already exists: 1611408124403 .
(/Users/cm/Realm/realm-java-release/realm/realm-library/src/main/cpp/io_realm_internal_OsObject.cpp:197)
       at io.realm.internal.OsObject.nativeCreateNewObjectWithLongPrimaryKey(OsObject.java)
       at io.realm.internal.OsObject.createWithPrimaryKey(OsObject.java:208)
       at io.realm.Realm.createObjectInternal(Realm.java:1049)
       at io.realm.Realm.createObject(Realm.java:1024)
       at org.macho.beforeandafter.shared.data.record.RecordDaoImpl$register$$inlined$use$lambda$1.execute(RecordDaoImpl.java:51)
       at io.realm.Realm.executeTransaction(Realm.java:1493)
       at org.macho.beforeandafter.shared.data.record.RecordDaoImpl.register(RecordDaoImpl.java:50)
       at org.macho.beforeandafter.shared.data.record.RecordRepositoryImpl$register$1.run(RecordRepositoryImpl.java:27)
       at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1112)
       at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:587)
       at java.lang.Thread.run(Thread.java:818)
```

以下を参考参考に、createObjectではなく、copyOrUpdateを使うよう変更。
> ライマリキーを指定したモデルについては、copyToRealmOrUpdate()を使ってオブジェクトを作成または更新をすることができます。 このメソッドは、プライマリキーが一致するデータがすでに存在すれば、データを更新し、無ければ新しくオブジェクトを作成します。 copyToRealmOrUpdate()をプライマリキーを持たないクラスに対して使用した場合は例外がスローされます。
> https://realm.io/jp/docs/java/latest/


# The user's Drive storage quota has been exceeded.

文字通り。catchして、ドライブに空きスペースがない旨メッセージを表示。

```

Caused by com.google.api.client.googleapis.json.GoogleJsonResponseException: 403 Forbidden
{
  "code": 403,
  "errors": [
    {
      "domain": "global",
      "message": "The user's Drive storage quota has been exceeded.",
      "reason": "storageQuotaExceeded"
    }
  ],
  "message": "The user's Drive storage quota has been exceeded."
}
       at com.google.api.client.googleapis.services.json.AbstractGoogleJsonClientRequest.newExceptionOnError(AbstractGoogleJsonClientRequest.java:113)
       at com.google.api.client.googleapis.services.json.AbstractGoogleJsonClientRequest.newExceptionOnError(AbstractGoogleJsonClientRequest.java:40)
       at com.google.api.client.googleapis.services.AbstractGoogleClientRequest.executeUnparsed(AbstractGoogleClientRequest.java:432)
       at com.google.api.client.googleapis.services.AbstractGoogleClientRequest.executeUnparsed(AbstractGoogleClientRequest.java:352)
       at com.google.api.client.googleapis.services.AbstractGoogleClientRequest.execute(AbstractGoogleClientRequest.java:469)
       at org.macho.beforeandafter.preference.backup.BackupTask.saveImage(BackupTask.java:154)
       at org.macho.beforeandafter.preference.backup.BackupTask.doInBackground(BackupTask.java:62)
       at org.macho.beforeandafter.preference.backup.BackupTask.doInBackground(BackupTask.java:22)
       at android.os.AsyncTask$3.call(AsyncTask.java:378)
       at java.util.concurrent.FutureTask.run(FutureTask.java:266)
       at android.os.AsyncTask$SerialExecutor$1.run(AsyncTask.java:289)
       at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1167)
       at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:641)
       at java.lang.Thread.run(Thread.java:919)
```