### PR TITLE
Fix Crashlytics crash: IllegalStateException dateButton must not be n…

### DIFF
--- a/app/src/main/java/org/macho/beforeandafter/preference/backup/BackupTask.kt
+++ b/app/src/main/java/org/macho/beforeandafter/preference/backup/BackupTask.kt
@@ -90,7 +90,7 @@ class BackupTask(context: Context, val account: Account, listener: BackupTaskLis
             return
 
         } catch (e: GoogleJsonResponseException) {
-            if (e.details.errors.any { errorInfo -> errorInfo.message.contains("The user's Drive storage quota has been exceeded.") }) {
+            if (e.details?.errors?.any { errorInfo -> errorInfo.message.contains("The user's Drive storage quota has been exceeded.") } == true) {
                 publishProgress(BackupStatus(BackupStatus.BACKUP_STATUS_CODE_ERROR_NO_ENOUGH_SPACE))
                 return
 

--- a/app/src/main/java/org/macho/beforeandafter/record/editaddrecord/EditAddRecordFragment.kt
+++ b/app/src/main/java/org/macho/beforeandafter/record/editaddrecord/EditAddRecordFragment.kt
@@ -245,6 +245,10 @@ class EditAddRecordFragment @Inject constructor() : DaggerFragment(), EditAddRec
             return // Workaround: IllegalStateException dateButton must not be null https://www.vvzixun.com/index.php/code/35ff970b286785750654dd580d0d491a
         }
 
+        if (view == null) {
+            return // Workaround: IllegalStateException dateButton must not be null. https://stackoverflow.com/a/19690491/8834586
+        }
+
         date?.let {
             dateButton.text = dateFormat.format(Date(it))
             dateButton.tag = Date(it)

--- a/app/src/main/java/org/macho/beforeandafter/record/editaddrecord/EditAddRecordFragment.kt
+++ b/app/src/main/java/org/macho/beforeandafter/record/editaddrecord/EditAddRecordFragment.kt
@@ -278,6 +278,11 @@ class EditAddRecordFragment @Inject constructor() : DaggerFragment(), EditAddRec
     }
 
     override fun close() {
+        // Workaround: IllegalStateException: Fragment EditAddRecordFragment ... not associated with a fragment manager.
+        if (!isAdded) {
+            return
+        }
+
         if (shouldShowInterstitialAd) {
             interstitialAd?.showIfNeeded(context!!)
         }


### PR DESCRIPTION
以下の通り、写真の撮影/写真の取得が完了→onActivityResult→updateViewsで発生している。

おそらく、viewが作成される前に、updateViewsでdateButtonにアクセスしているためと思われる。

以下によると、Androidはメモリが逼迫しているとき、表示されていないActivityを破棄するらしい。そのため、写真を取得している間に、MainActivityが破棄されて、取得完了し戻ってきたときに再生成していると思われる。再生成する前にupdateViewsでdateButtonにアクセスしようとしているのではないか。

> This is the nature of android if your device needs memory it destroys activities which are not visible. So you have to consider that your activity can be recreated any time.
> https://stackoverflow.com/a/19690491/8834586

```
Caused by java.lang.IllegalStateException: dateButton must not be null
       at org.macho.beforeandafter.record.editaddrecord.EditAddRecordFragment.updateViews(EditAddRecordFragment.java:249)
       at org.macho.beforeandafter.record.editaddrecord.EditAddRecordPresenter.updateViews(EditAddRecordPresenter.java:207)
       at org.macho.beforeandafter.record.editaddrecord.EditAddRecordPresenter.modifyFrontImage(EditAddRecordPresenter.java:72)
       at org.macho.beforeandafter.record.editaddrecord.EditAddRecordFragment.onActivityResult(EditAddRecordFragment.java:155)
       at androidx.fragment.app.FragmentActivity.onActivityResult(FragmentActivity.java:177)
       at org.macho.beforeandafter.main.MainActivity.onActivityResult(MainActivity.java:121)
       at android.app.Activity.dispatchActivityResult(Activity.java:8393)
       at android.app.ActivityThread.deliverResults(ActivityThread.java:5442)
       at android.app.ActivityThread.handleSendResult(ActivityThread.java:5490)
       at android.app.servertransaction.ActivityResultItem.execute(ActivityResultItem.java:51)
       at android.app.servertransaction.TransactionExecutor.executeCallbacks(TransactionExecutor.java:149)
       at android.app.servertransaction.TransactionExecutor.execute(TransactionExecutor.java:103)
       at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2373)
       at android.os.Handler.dispatchMessage(Handler.java:107)
       at android.os.Looper.loop(Looper.java:213)
       at android.app.ActivityThread.main(ActivityThread.java:8147)
       at java.lang.reflect.Method.invoke(Method.java)
       at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:513)
       at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1101)
```