### PR TITLE
Fix camera preview aspect ratio bug

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -25,7 +25,7 @@
         <activity android:name=".InitialSettingsActivity" />
 
         <activity android:name=".main.MainActivity" />
-        <activity android:name=".record.camera.CameraActivity" android:theme="@style/AppThemeNoTitle"/>
+        <activity android:name=".record.camera.CameraActivity" android:theme="@style/AppThemeNoTitle" android:screenOrientation="portrait"/>
         <activity android:name=".gallery.PhotoActivity" android:theme="@style/MainTheme"/>
         <activity android:name=".PinAuthActivity" android:theme="@style/AppThemeNoTitle"/>
         <activity android:name=".preference.pin.PinEnableActivity" android:theme="@style/AppThemeNoTitle"/>

--- a/app/src/main/java/org/macho/beforeandafter/record/editaddrecord/EditAddRecordPresenter.kt
+++ b/app/src/main/java/org/macho/beforeandafter/record/editaddrecord/EditAddRecordPresenter.kt
@@ -113,7 +113,7 @@ class EditAddRecordPresenter @Inject constructor(val recordRepository: RecordRep
                     .filter { it.date > startTime }
                     .sortedBy { it.date * multiplier }
                     .map(mapper)
-                    .firstOrNull{ it?.isNotEmpty() ?: false }
+                    .firstOrNull{ !it.isNullOrEmpty() && File(context.filesDir, it).exists() }
             view?.openCamera(guidePhotoFileName)
         }
     }


### PR DESCRIPTION
互いにサイズの異なるpreviewをtextureViewで表示しようとすると、縦方向に潰れたり、横方向に潰れたり（縦に伸びたり）する。

それを防ぐため、previewがtextureViewにフィットするように修正。

textureViewにはscaleTypeのような属性はないので、textureView.setTransform(matrix)で、previewがTextureViewにすっぽり収まるように修正した。